### PR TITLE
🐛 Fix PIL Path Error

### DIFF
--- a/src/nonebot_plugin_deer_pipe/constants.py
+++ b/src/nonebot_plugin_deer_pipe/constants.py
@@ -17,8 +17,8 @@ CHECK_IMG: ImageFile    = Image.open(ASSETS_PATH / "check@96x100.png")
 DEERPIPE_IMG: ImageFile = Image.open(ASSETS_PATH / "deerpipe@100x82.png")
 
 # Fonts
-MISANS_FONT: FreeTypeFont = ImageFont.truetype(str(
-  ASSETS_PATH / "MiSans-Regular.ttf"),
+MISANS_FONT: FreeTypeFont = ImageFont.truetype(
+  str(ASSETS_PATH / "MiSans-Regular.ttf"),
   25
 )
 

--- a/src/nonebot_plugin_deer_pipe/constants.py
+++ b/src/nonebot_plugin_deer_pipe/constants.py
@@ -17,8 +17,8 @@ CHECK_IMG: ImageFile    = Image.open(ASSETS_PATH / "check@96x100.png")
 DEERPIPE_IMG: ImageFile = Image.open(ASSETS_PATH / "deerpipe@100x82.png")
 
 # Fonts
-MISANS_FONT: FreeTypeFont = ImageFont.truetype(
-  ASSETS_PATH / "MiSans-Regular.ttf",
+MISANS_FONT: FreeTypeFont = ImageFont.truetype(str(
+  ASSETS_PATH / "MiSans-Regular.ttf"),
   25
 )
 


### PR DESCRIPTION
Fix the error i'm encountering indicates that the `ImageFont.truetype` method in the `PIL` (Python Imaging Library) module is receiving a `WindowsPath` object instead of a string or bytes object, which is causing the `AttributeError`.